### PR TITLE
🐛 BugFix : 모바일에서 40개 이하 파일 다운로드 지원까지는 가능하도록 수정

### DIFF
--- a/src/utils/downloadUtils.js
+++ b/src/utils/downloadUtils.js
@@ -1,4 +1,5 @@
-// 디버깅 로그 함수 - 필요시 false로 변경
+// 로그 메세지 출력 여부 설정 true 는 출력, false 는 출력 안함
+// **************중요************** 배포 시에는 false로 설정해야 함
 const ENABLE_LOGGING = false;
 const debug = (message, data) => {
   if (ENABLE_LOGGING) {

--- a/src/workers/zipWorker.js
+++ b/src/workers/zipWorker.js
@@ -1,6 +1,7 @@
 import { zip } from 'fflate';
 
-// 로깅 설정 - 필요 없으면 false로 설정
+// 로그 메세지 출력 여부 설정 true 는 출력, false 는 출력 안함
+// **************중요************** 배포 시에는 false로 설정해야 함
 const ENABLE_LOGGING = false;
 
 /**


### PR DESCRIPTION
- 모바일에서 40개 이하의 파일까지는 다운로드가 가능하도록 버그 픽스(불완전) zipWorker.js에서 압축 프로세스 중 메모리 관리 최적화